### PR TITLE
Fixes for async tab opening and alerts

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,12 +1,61 @@
 let visitedUrls = new Set();
 let matchedLinks = new Map();
+let crawlingInProgress = false;
+let crawlQueue = new Set();
+let pendingVolumeUrls = new Set();
+let pendingIssueUrls = new Set();
 let followedLinksCount = 0;
 let maxLinks = 5;
 let config = {};
-stage = config.volume_pattern ? 'volume' : 'issue';
+let stage = 'issue';
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function crawlNext() {
+  if (crawlingInProgress) return;
+  crawlingInProgress = true;
+
+  while (crawlQueue.size > 0 && (maxLinks === null || followedLinksCount < maxLinks)) {
+    const nextUrl = crawlQueue.values().next().value;
+    crawlQueue.delete(nextUrl);
+    if (pendingVolumeUrls.has(nextUrl)) pendingVolumeUrls.delete(nextUrl);
+
+    if (visitedUrls.has(nextUrl)) continue;
+    visitedUrls.add(nextUrl);
+    followedLinksCount++;
+
+    console.log(`[Background] Crawling link (${followedLinksCount}/${maxLinks || '∞'}): ${nextUrl}`);
+
+    try {
+      await processIssueLink(nextUrl);
+      await delay(1000);
+    } catch (err) {
+      console.error(`[Background] Error processing link ${nextUrl}:`, err);
+    }
+  }
+
+  if (stage === 'volume' && crawlQueue.size === 0 && pendingVolumeUrls.size === 0) {
+    console.log('[Background] Volume stage complete — switching to issue stage.');
+    stage = 'issue';
+    followedLinksCount = 0;
+
+    pendingIssueUrls.forEach(url => {
+      if (!visitedUrls.has(url)) {
+        crawlQueue.add(url);
+      }
+    });
+    crawlingInProgress = false;
+    console.log('[Background] CrawlQueue after moving issue URLs:', crawlQueue.size);
+    pendingIssueUrls.clear();
+
+    if (crawlQueue.size > 0) {
+      await crawlNext();
+    }
+  }
+
+  crawlingInProgress = false;
 }
 
 async function processIssueLink(link) {
@@ -69,6 +118,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     matchedLinks.clear();
     followedLinksCount = 0;
     stage = config.volume_pattern ? 'volume' : 'issue';
+
+    crawlQueue.clear();
+    pendingVolumeUrls.clear();
+    pendingIssueUrls.clear();
   }
 
   if (message.type === 'REQUEST_LINKS') {
@@ -82,45 +135,32 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const issueRegex = new RegExp(config.crawl_pattern);
     const extractionRegex = new RegExp(config.extraction_pattern);
 
-    const currentUrl = sender.tab.url;
-    let crawlCandidates = [];
-
     if (stage === 'volume') {
-      crawlCandidates = links.filter(item => volumeRegex.test(item.link));
+      links.forEach(item => {
+        if (volumeRegex.test(item.link) && !visitedUrls.has(item.link) && !pendingVolumeUrls.has(item.link)) {
+          pendingVolumeUrls.add(item.link);
+          crawlQueue.add(item.link);
+        }
+      });
+
+      links.forEach(item => {
+        if (issueRegex.test(item.link) && !visitedUrls.has(item.link) && !pendingIssueUrls.has(item.link)) {
+          pendingIssueUrls.add(item.link);
+        }
+      });
+
     } else if (stage === 'issue') {
-      crawlCandidates = links.filter(item => issueRegex.test(item.link));
+      links.forEach(item => {
+        if (issueRegex.test(item.link) && !visitedUrls.has(item.link)) {
+          crawlQueue.add(item.link);
+        }
+      });
     }
 
-    const toFollow = [];
+    console.log(`[Background] Queues state - crawlQueue size: ${crawlQueue.size}, pendingVolumeUrls size: ${pendingVolumeUrls.size}, pendingIssueUrls size: ${pendingIssueUrls.size}`);
 
-    crawlCandidates.forEach(item => {
-      if (!visitedUrls.has(item.link) && (maxLinks === null || followedLinksCount < maxLinks)) {
-        visitedUrls.add(item.link);
-        followedLinksCount++;
-        toFollow.push(item.link);
-      }
-    });
-
-    console.log(`[Background] Found ${toFollow.length} links to follow:`, toFollow);
-
-    if (config.crawl && toFollow.length > 0) {
-      (async () => {
-        for (const link of toFollow) {
-          await processIssueLink(link);
-          await delay(1000);
-        }
-
-        if (stage === 'volume') {
-          stage = 'issue';
-          followedLinksCount = 0;
-
-          const volumeLinks = Array.from(visitedUrls);
-          for (const link of volumeLinks) {
-            await processIssueLink(link);
-            await delay(1000);
-          }
-        }
-      })();
+    if (config.crawl && !crawlingInProgress) {
+      crawlNext();
     }
 
     const extractionMatches = links.filter(item => extractionRegex.test(item.link));

--- a/background.js
+++ b/background.js
@@ -104,7 +104,7 @@ async function processIssueLink(link) {
       timeoutId = setTimeout(() => {
         console.warn(`[Background] Timeout on tab ${tabId}`);
         cleanup();
-      }, 7000);
+      }, 10000);
       chrome.runtime.onMessage.addListener(onExtracted);
     });
   });

--- a/manifest.json
+++ b/manifest.json
@@ -12,13 +12,6 @@
   "background": {
     "service_worker": "background.js"
   },
-    "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["content-script.js"],
-      "run_at": "document_end"
-    }
-  ],
     "web_accessible_resources": [
     {
       "resources": ["site-config.json"],

--- a/popup.html
+++ b/popup.html
@@ -54,6 +54,7 @@
       <input type="text" id="serverUrl" placeholder="e.g., http://localhost/cgi-bin/record_aggregator/submit_feed">
     </div>
   </div>
+  <div id="serverResponse" style="margin-top: 10px; font-weight: bold; color: #333;"></div>
   <div id="links"></div>
   <div class="section">
     <button id="send" hidden>Send Articles to Server/CGI</button>

--- a/popup.js
+++ b/popup.js
@@ -106,7 +106,9 @@ chrome.runtime.onMessage.addListener((message) => {
 // Send selected links to server/cgi
 sendButton.addEventListener('click', async () => {
   if (extractedLinks.length === 0) {
-    alert('No links to send.');
+    const responseBox = document.getElementById('serverResponse');
+    responseBox.textContent = 'No links to send.';
+    responseBox.style.color = 'red';
     return;
   }
 
@@ -127,7 +129,9 @@ sendButton.addEventListener('click', async () => {
   try {
     new URL(url);
   } catch (e) {
-    alert('Invalid URL. Please check the Server/CGI URL field.');
+    const responseBox = document.getElementById('serverResponse');
+    responseBox.textContent = 'Invalid URL. Please check the Server/CGI URL field.';
+    responseBox.style.color = 'red';
     return;
   }
 
@@ -141,10 +145,14 @@ sendButton.addEventListener('click', async () => {
     });
 
     const result = await response.text();
-    alert(`Server response: ${result}`);
+    const responseBox = document.getElementById('serverResponse');
+    responseBox.textContent = `Server response: ${result}`;
+    responseBox.style.color = 'green';
   } catch (err) {
     console.error('Failed to send feed:', err);
-    alert('Failed to send feed. Check console for details.');
+    const responseBox = document.getElementById('serverResponse');
+    responseBox.textContent = 'Failed to send feed. Check console for details.';
+    responseBox.style.color = 'red';
   }
 });
 
@@ -153,7 +161,9 @@ downloadButton.addEventListener('click', () => {
   chrome.runtime.sendMessage({ type: 'REQUEST_LINKS' }, (response) => {
     const links = response.links || [];
     if (links.length === 0) {
-      alert('No links to download.');
+      const responseBox = document.getElementById('serverResponse');
+      responseBox.textContent = 'No links to download.';
+      responseBox.style.color = 'red';
       return;
     }
 

--- a/site-config.json
+++ b/site-config.json
@@ -80,5 +80,33 @@
       "linkAttr": "href"
     },
     "max_links": 5
+  },
+  "zwingliana.ch": {
+    "pattern": "zwingliana\\.ch/issue/archive",
+    "volume_pattern": "",
+    "crawl_pattern": "https://zwingliana\\.ch/issue/view/\\d+$",
+    "extraction_pattern": "https://zwingliana\\.ch/article/view/\\d+$",
+    "crawl": true,
+    "site": "Zwingliana : Beiträge zur Geschichte des Protestantismus in der Schweiz und seiner Ausstrahlung",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "koersjournal.org.za": {
+    "pattern": "www\\.koersjournal\\.org\\.za/index\\.php/koers/issue/archive/?",
+    "volume_pattern": "www\\.koersjournal\\.org\\.za/index\\.php/koers/issue/archive/\\d+$",
+    "crawl_pattern": "www\\.koersjournal\\.org\\.za/index\\.php/koers/issue/view/\\d+$",
+    "extraction_pattern": "www\\.koersjournal\\.org\\.za/index\\.php/koers/article/view/\\d+$",
+    "crawl": true,
+    "site": "Koers : Bulletin for Christian Scholarship = Koers : Bulletin vir Christelike Wetenskap",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
   }
 }

--- a/site-config.json
+++ b/site-config.json
@@ -239,12 +239,12 @@
     "pattern": "https://dialnet\\.unirioja\\.es/servlet/revista\\?codigo=649",
     "volume_pattern": "",
     "crawl_pattern": "https://dialnet\\.unirioja\\.es/ejemplar/\\d+$",
-    "extraction_pattern": "https://dialnet.unirioja.es/servlet/articulo?codigo=\\d+$",
+    "extraction_pattern": "https://dialnet\\.unirioja\\.es/servlet/articulo\\?codigo=\\d+$",
     "crawl": true,
     "site": "Hispania sacra : revista de historia eclesiástica",
     "selectors": {
-      "linkSelector": null,
-      "titleSelector": null,
+      "linkSelector": "a",
+      "titleSelector": "span.substitulo",
       "linkAttr": "href"
     },
     "max_links": 5

--- a/site-config.json
+++ b/site-config.json
@@ -108,5 +108,145 @@
       "linkAttr": "href"
     },
     "max_links": 5
+  },
+    "https://onlinelibrary.wiley.com/loi/15406385": {
+    "pattern": "onlinelibrary\\.wiley\\.com/loi/15406385(/year/\\d{4})?",
+    "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/15406385/year/\\d{4}$",
+    "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/15406385/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
+    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/10\\.1111/((j\\.)?1540-6385\\.\\d+(?:\\.\\w+\\.x)?|dial\\.\\d+)",
+    "crawl": true,
+    "site": "Dialog : a journal of theology",
+    "selectors": {
+      "linkSelector": "a.href",
+      "titleSelector": "h2",
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "https://onlinelibrary.wiley.com/loi/17586631": {
+    "pattern": "onlinelibrary\\.wiley\\.com/loi/17586631(/year/\\d{4})?",
+    "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/17586631/year/\\d{4}$",
+    "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/17586631/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
+    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/10\\.1111/((j\\.)?1758-6631\\.\\d+(?:\\.\\w+\\.x)?|irom\\.\\d+)",
+    "crawl": true,
+    "site": "International review of mission",
+    "selectors": {
+      "linkSelector": "a.href",
+      "titleSelector": "h2",
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "https://onlinelibrary.wiley.com/loi/14679647": {
+    "pattern": "onlinelibrary\\.wiley\\.com/loi/14679647(/year/\\d{4})?",
+    "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/14679647/year/\\d{4}$",
+    "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/14679647/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
+    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/10\\.1111/((j\\.)?1467-9647\\.\\d+(?:\\.\\w+\\.x)?|teth\\.\\d+)",
+    "crawl": true,
+    "site": "Teaching theology and religion",
+    "selectors": {
+      "linkSelector": "a.href",
+      "titleSelector": "h2",
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "https://onlinelibrary.wiley.com/loi/17586623": {
+    "pattern": "onlinelibrary\\.wiley\\.com/loi/17586623(/year/\\d{4})?",
+    "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/17586623/year/\\d{4}$",
+    "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/17586623/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
+    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/10\\.1111/((j\\.)?1758-6623\\.\\d+(?:\\.\\w+\\.x)?|erev\\.\\d+)",
+    "crawl": true,
+    "site": "The ecumenical review",
+    "selectors": {
+      "linkSelector": "a.href",
+      "titleSelector": "h2",
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "https://onlinelibrary.wiley.com/loi/1552146x": {
+    "pattern": "onlinelibrary\\.wiley\\.com/loi/1552146x(/year/\\d{4})?",
+    "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/1552146x/year/\\d{4}$",
+    "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/1552146x/\\d{4}/\\d+/\\w?(\\d+|\\d+-\\d+)$",
+    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/10\\.(1002|2307|1353)/(\\d+|hast\\.\\d+|\\w+\\.\\d+\\.\\d+)",
+    "crawl": true,
+    "site": "The Hastings Center report",
+    "selectors": {
+      "linkSelector": "a.href",
+      "titleSelector": "h2",
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "https://onlinelibrary.wiley.com/loi/17576547": {
+    "pattern": "onlinelibrary\\.wiley\\.com/loi/17576547(/year/\\d{4})?",
+    "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/17576547/year/\\d{4}$",
+    "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/(17576547|18359310)/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
+    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/10\\.1111/((j\\.)?\\d{4}-\\d{4}\\.\\d+(?:\\.\\w+\\.x)?|taja\\.\\d+)",
+    "crawl": true,
+    "site": "The Australian journal of anthropology : official journal of the Australian Anthropological Society",
+    "selectors": {
+      "linkSelector": "a.href",
+      "titleSelector": "h2",
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "https://onlinelibrary.wiley.com/loi/14679205": {
+    "pattern": "onlinelibrary\\.wiley\\.com/loi/14679205(/year/\\d{4})?",
+    "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/14679205/year/\\d{4}$",
+    "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/14679205/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
+    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/10\\.1111/((j\\.)?\\d{4}-\\d{4}\\.\\d+(?:\\.\\w+\\.x)?|phin\\.\\d+)",
+    "crawl": true,
+    "site": "Philosophical investigations",
+    "selectors": {
+      "linkSelector": "a.href",
+      "titleSelector": "h2",
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "anthrosource.onlinelibrary.wiley.com/loi/15481352": {
+    "pattern": "onlinelibrary\\.wiley\\.com/loi/15481352(/year/\\d{4})?",
+    "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/15481352/year/\\d{4}$",
+    "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/15481352/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
+    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/(10\\.(1111|1525)/[A-Za-z0-9.\\-]+)",
+    "crawl": true,
+    "site": "Ethos : journal of the Society for Psychological Anthropology",
+    "selectors": {
+      "linkSelector": "a.href",
+      "titleSelector": "h2",
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "https://hispaniasacra.revistas.csic.es": {
+    "pattern": "https://hispaniasacra\\.revistas\\.csic\\.es/index\\.php/hispaniasacra/issue/(archive|view/\\d+)$",
+    "volume_pattern": "",
+    "crawl_pattern": "https://hispaniasacra\\.revistas\\.csic\\.es/index\\.php/hispaniasacra/issue/view/\\d+$",
+    "extraction_pattern": "https://hispaniasacra\\.revistas\\.csic\\.es/index\\.php/hispaniasacra/article/view/\\d+$",
+    "crawl": true,
+    "site": "Hispania sacra : revista de historia eclesiástica",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "https://dialnet.unirioja.es/": {
+    "pattern": "https://dialnet\\.unirioja\\.es/servlet/revista\\?codigo=649",
+    "volume_pattern": "",
+    "crawl_pattern": "https://dialnet\\.unirioja\\.es/ejemplar/\\d+$",
+    "extraction_pattern": "https://dialnet.unirioja.es/servlet/articulo?codigo=\\d+$",
+    "crawl": true,
+    "site": "Hispania sacra : revista de historia eclesiástica",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
   }
 }

--- a/site-config.json
+++ b/site-config.json
@@ -109,7 +109,7 @@
     },
     "max_links": 5
   },
-    "https://onlinelibrary.wiley.com/loi/15406385": {
+    "onlinelibrary.wiley.com/loi/15406385": {
     "pattern": "onlinelibrary\\.wiley\\.com/loi/15406385(/year/\\d{4})?",
     "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/15406385/year/\\d{4}$",
     "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/15406385/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
@@ -123,7 +123,7 @@
     },
     "max_links": 5
   },
-    "https://onlinelibrary.wiley.com/loi/17586631": {
+    "onlinelibrary.wiley.com/loi/17586631": {
     "pattern": "onlinelibrary\\.wiley\\.com/loi/17586631(/year/\\d{4})?",
     "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/17586631/year/\\d{4}$",
     "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/17586631/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
@@ -137,7 +137,7 @@
     },
     "max_links": 5
   },
-    "https://onlinelibrary.wiley.com/loi/14679647": {
+    "onlinelibrary.wiley.com/loi/14679647": {
     "pattern": "onlinelibrary\\.wiley\\.com/loi/14679647(/year/\\d{4})?",
     "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/14679647/year/\\d{4}$",
     "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/14679647/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
@@ -151,7 +151,7 @@
     },
     "max_links": 5
   },
-    "https://onlinelibrary.wiley.com/loi/17586623": {
+    "onlinelibrary.wiley.com/loi/17586623": {
     "pattern": "onlinelibrary\\.wiley\\.com/loi/17586623(/year/\\d{4})?",
     "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/17586623/year/\\d{4}$",
     "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/17586623/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
@@ -165,7 +165,7 @@
     },
     "max_links": 5
   },
-    "https://onlinelibrary.wiley.com/loi/1552146x": {
+    "onlinelibrary.wiley.com/loi/1552146x": {
     "pattern": "onlinelibrary\\.wiley\\.com/loi/1552146x(/year/\\d{4})?",
     "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/1552146x/year/\\d{4}$",
     "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/1552146x/\\d{4}/\\d+/\\w?(\\d+|\\d+-\\d+)$",
@@ -179,7 +179,7 @@
     },
     "max_links": 5
   },
-    "https://onlinelibrary.wiley.com/loi/17576547": {
+    "onlinelibrary.wiley.com/loi/17576547": {
     "pattern": "onlinelibrary\\.wiley\\.com/loi/17576547(/year/\\d{4})?",
     "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/17576547/year/\\d{4}$",
     "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/(17576547|18359310)/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
@@ -193,7 +193,7 @@
     },
     "max_links": 5
   },
-    "https://onlinelibrary.wiley.com/loi/14679205": {
+    "onlinelibrary.wiley.com/loi/14679205": {
     "pattern": "onlinelibrary\\.wiley\\.com/loi/14679205(/year/\\d{4})?",
     "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/14679205/year/\\d{4}$",
     "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/14679205/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
@@ -221,7 +221,7 @@
     },
     "max_links": 5
   },
-    "https://hispaniasacra.revistas.csic.es": {
+    "hispaniasacra.revistas.csic.es": {
     "pattern": "https://hispaniasacra\\.revistas\\.csic\\.es/index\\.php/hispaniasacra/issue/(archive|view/\\d+)$",
     "volume_pattern": "",
     "crawl_pattern": "https://hispaniasacra\\.revistas\\.csic\\.es/index\\.php/hispaniasacra/issue/view/\\d+$",
@@ -235,7 +235,7 @@
     },
     "max_links": 5
   },
-    "https://dialnet.unirioja.es/": {
+    "dialnet.unirioja.es": {
     "pattern": "https://dialnet\\.unirioja\\.es/servlet/revista\\?codigo=649",
     "volume_pattern": "",
     "crawl_pattern": "https://dialnet\\.unirioja\\.es/ejemplar/\\d+$",
@@ -245,6 +245,48 @@
     "selectors": {
       "linkSelector": "a",
       "titleSelector": "span.substitulo",
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "revistas.agustinosvalladolid.es": {
+    "pattern": "https://revistas\\.agustinosvalladolid\\.es/index\\.php/estudio/issue/archive(/\\d+)?",
+    "volume_pattern": "https://revistas\\.agustinosvalladolid\\.es/index\\.php/estudio/issue/archive/\\d+$",
+    "crawl_pattern": "https://revistas\\.agustinosvalladolid\\.es/index\\.php/estudio/issue/view/\\d+$",
+    "extraction_pattern": "https://revistas\\.agustinosvalladolid\\.es/index\\.php/estudio/article/view/\\d+$",
+    "crawl": true,
+    "site": "Estudio agustiniano",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "revistas.est.edu.br": {
+    "pattern": "https://revistas\\.est\\.edu\\.br/ET/issue/archive(/\\d+)?",
+    "volume_pattern": "https://revistas\\.est\\.edu\\.br/ET/issue/archive(/\\d+)?$",
+    "crawl_pattern": "https://revistas\\.est\\.edu\\.br/ET/issue/view/\\d+$",
+    "extraction_pattern": "https://revistas\\.est\\.edu\\.br/ET/article/view/\\d+$",
+    "crawl": true,
+    "site": "Estudos Teológicos : órgão semestral editado pela Escola Superior de Teologia, Instituto Ecum",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "tyndalebulletin.org": {
+    "pattern": "https://www\\.tyndalebulletin\\.org/issues",
+    "volume_pattern": "",
+    "crawl_pattern": "https://www\\.tyndalebulletin\\.org/issue/\\d+$",
+    "extraction_pattern": "https://www\\.tyndalebulletin\\.org/article/\\d+",
+    "crawl": true,
+    "site": "Tyndale bulletin : organ of the Tyndale Fellowship for Biblical and Theological Research and of Tyndale House",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
       "linkAttr": "href"
     },
     "max_links": 5

--- a/site-config.json
+++ b/site-config.json
@@ -66,5 +66,19 @@
       "linkAttr": "href"
     },
     "max_links": 5
+  },
+  "foi-et-vie.fr": {
+    "pattern": "https://www\\.foi-et-vie\\.fr/archive/?",
+    "volume_pattern": "https://www\\.foi-et-vie\\.fr/archive/byyear\\.php#year=(19\\d{2}|[2-9]\\d{3})",
+    "crawl_pattern": "https://www\\.foi-et-vie\\.fr/archive/review.php\\?code=\\d{4}_\\d+$",
+    "extraction_pattern": "https://www\\.foi-et-vie\\.fr/archive/article.php\\?code=\\d+$",
+    "crawl": true,
+    "site": "Foi & vie : revue de culture protestante",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
   }
 }

--- a/site-config.json
+++ b/site-config.json
@@ -82,7 +82,7 @@
     "max_links": 5
   },
   "zwingliana.ch": {
-    "pattern": "zwingliana\\.ch/issue/archive",
+    "pattern": "zwingliana\\.ch/issue/(archive|view/\\d+)",
     "volume_pattern": "",
     "crawl_pattern": "https://zwingliana\\.ch/issue/view/\\d+$",
     "extraction_pattern": "https://zwingliana\\.ch/article/view/\\d+$",
@@ -113,7 +113,7 @@
     "pattern": "onlinelibrary\\.wiley\\.com/loi/15406385(/year/\\d{4})?",
     "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/15406385/year/\\d{4}$",
     "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/15406385/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
-    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/10\\.1111/((j\\.)?1540-6385\\.\\d+(?:\\.\\w+\\.x)?|dial\\.\\d+)",
+    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/10\\.1111/((j\\.)?\\d{4}-\\d{4}\\.\\d+(?:\\.\\w+\\.x)?|dial\\.\\d+|\\d+-\\d+\\.\\d+)",
     "crawl": true,
     "site": "Dialog : a journal of theology",
     "selectors": {
@@ -278,12 +278,124 @@
     "max_links": 5
   },
     "tyndalebulletin.org": {
-    "pattern": "https://www\\.tyndalebulletin\\.org/issues",
+    "pattern": "https://www\\.tyndalebulletin\\.org/issue(s|/\\d+)?",
     "volume_pattern": "",
     "crawl_pattern": "https://www\\.tyndalebulletin\\.org/issue/\\d+$",
     "extraction_pattern": "https://www\\.tyndalebulletin\\.org/article/\\d+",
     "crawl": true,
     "site": "Tyndale bulletin : organ of the Tyndale Fellowship for Biblical and Theological Research and of Tyndale House",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "onlinelibrary.wiley.com/loi/2161007X": {
+    "pattern": "onlinelibrary\\.wiley\\.com/loi/2161007X(/year/\\d{4})?",
+    "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/2161007x/year/\\d{4}$",
+    "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/(2161007x|21645183)/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
+    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/10\\.\\d{4}/((j\\.)?\\d{4}-\\d+\\w?\\.\\d+(?:\\.\\w+\\.x)?|cvj\\.\\d+)",
+    "crawl": true,
+    "site": "Counseling and values : official journal of the National Catholic Guidance Conference",
+    "selectors": {
+      "linkSelector": "a.href",
+      "titleSelector": "h2",
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "revistas.pucsp.br": {
+    "pattern": "https://revistas\\.pucsp\\.br/index\\.php/culturateo/issue/archive(/\\d+)?",
+    "volume_pattern": "https://revistas\\.pucsp\\.br/index\\.php/culturateo/issue/archive(/\\d+)?$",
+    "crawl_pattern": "https://revistas\\.pucsp\\.br/index\\.php/culturateo/issue/view/\\d+$",
+    "extraction_pattern": "https://revistas\\.pucsp\\.br/index\\.php/culturateo/article/view/(rct\\.v\\d+i\\d+\\.\\d+|rct\\.i\\d+\\.\\d+|\\d+)$",
+    "crawl": true,
+    "site": "Revista de cultura teológica",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "revistaseletronicas.pucrs.br/teo": {
+    "pattern": "https://revistaseletronicas\\.pucrs\\.br/teo/issue/archive(/\\d+)?",
+    "volume_pattern": "https://revistaseletronicas\\.pucrs\\.br/teo/issue/archive(/\\d+)?$",
+    "crawl_pattern": "https://revistaseletronicas\\.pucrs\\.br/teo/issue/view/\\d+$",
+    "extraction_pattern": "https://revistaseletronicas\\.pucrs\\.br/teo/article/view/\\d+$",
+    "crawl": true,
+    "site": "Teocomunicação : revista trimestral de teologia",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "periodicos.pucminas.br/horizonte": {
+    "pattern": "https://periodicos\\.pucminas\\.br/horizonte/issue/archive",
+    "volume_pattern": "",
+    "crawl_pattern": "https://periodicos\\.pucminas\\.br/horizonte/issue/view/\\d+$",
+    "extraction_pattern": "https://periodicos\\.pucminas\\.br/horizonte/article/view/(P\\.\\d{4}-\\d{4}\\.\\d+\\w+)?\\d+(-\\d+)?$",
+    "crawl": true,
+    "site": "Horizonte : Revista de Estudos de Teologia e Ciências da Religião",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "digitalcommons.unomaha.edu/jrf": {
+    "pattern": "https://digitalcommons\\.unomaha\\.edu/jrf/(all_issues\\.html|vol\\d+/)$",
+    "volume_pattern": "",
+    "crawl_pattern": "https://digitalcommons\\.unomaha\\.edu/jrf/vol\\d+/iss\\d+/$",
+    "extraction_pattern": "https://digitalcommons\\.unomaha\\.edu/jrf/vol\\d+/iss\\d+/\\d+$",
+    "crawl": true,
+    "site": "The Journal of Religion and Film",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "unipub.uni-graz.at/oerf": {
+    "pattern": "https://unipub\\.uni-graz\\.at/oerf\\?offset=\\d+$",
+    "volume_pattern": "https://unipub\\.uni-graz\\.at/oerf\\?offset=\\d+$",
+    "crawl_pattern": "https://unipub\\.uni-graz\\.at/oerf/periodical/titleinfo/\\d+$",
+    "extraction_pattern": "https://unipub\\.uni-graz\\.at/oerf/content/titleinfo/\\d+$",
+    "crawl": true,
+    "site": "Österreichisches Religionspädagogisches Forum",
+    "selectors": {
+      "linkSelector": "a.scap",
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "dialnet.unirioja.es/servlet": {
+    "pattern": "https://dialnet\\.unirioja\\.es/servlet/revista\\?codigo=1218$",
+    "volume_pattern": "",
+    "crawl_pattern": "https://dialnet\\.unirioja\\.es/ejemplar/\\d+$",
+    "extraction_pattern": "https://dialnet\\.unirioja\\.es/servlet/articulo\\?codigo=\\d+$",
+    "crawl": true,
+    "site": "Revista española de derecho canónico",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+  "brepolsonline.net/loi/rea": {
+    "pattern": "https://www\\.brepolsonline\\.net/loi/rea",
+    "volume_pattern": "",
+    "crawl_pattern": "https://www\\.brepolsonline\\.net/toc/rea/\\d{4}/\\d+/\\d+$",
+    "extraction_pattern": "https://www\\.brepolsonline\\.net/doi/abs/10\\.\\d{4}/J\\.REA\\.\\d\\.\\d+$",
+    "crawl": true,
+    "site": "Revue des études augustiniennes",
     "selectors": {
       "linkSelector": null,
       "titleSelector": null,

--- a/site-config.json
+++ b/site-config.json
@@ -389,6 +389,20 @@
     },
     "max_links": 5
   },
+    "revistas.upsa.es": {
+    "pattern": "https://revistas\\.upsa\\.es/index.php/derechocanonico/issue/archive$",
+    "volume_pattern": "",
+    "crawl_pattern": "https://revistas\\.upsa\\.es/index.php/derechocanonico/issue/view/\\d+$",
+    "extraction_pattern": "https://revistas\\.upsa\\.es/index.php/derechocanonico/article/view/\\d+$",
+    "crawl": true,
+    "site": "Revista española de derecho canónico",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
   "brepolsonline.net/loi/rea": {
     "pattern": "https://www\\.brepolsonline\\.net/loi/rea",
     "volume_pattern": "",
@@ -396,6 +410,174 @@
     "extraction_pattern": "https://www\\.brepolsonline\\.net/doi/abs/10\\.\\d{4}/J\\.REA\\.\\d\\.\\d+$",
     "crawl": true,
     "site": "Revue des études augustiniennes",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+  "hts.org.za": {
+    "pattern": "https://hts\\.org\\.za/index\\.php/hts/issue/archive(\\?issuesPage=\\d+)?$",
+    "volume_pattern": "https://hts\\.org\\.za/index\\.php/hts/issue/archive(\\?issuesPage=\\d+)?$",
+    "crawl_pattern": "https://hts\\.org\\.za/index\\.php/hts/issue/view/\\d+$",
+    "extraction_pattern": "https://hts\\.org\\.za/index\\.php/hts/article/view/\\d+$",
+    "crawl": true,
+    "site": "Hervormde teologiese studies",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+  "revistaeclesiasticabrasileira.itf.edu.br": {
+    "pattern": "https://revistaeclesiasticabrasileira\\.itf\\.edu\\.br/reb/issue/archive(/\\d+)?$",
+    "volume_pattern": "https://revistaeclesiasticabrasileira\\.itf\\.edu\\.br/reb/issue/archive(/\\d+)?$",
+    "crawl_pattern": "https://revistaeclesiasticabrasileira\\.itf\\.edu\\.br/reb/issue/view/\\d+$",
+    "extraction_pattern": "https://revistaeclesiasticabrasileira\\.itf\\.edu\\.br/reb/article/view/\\d+$",
+    "crawl": true,
+    "site": "Revista eclesiástica brasileira : REB",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "onlinelibrary.wiley.com/loi/14682303": {
+    "pattern": "onlinelibrary\\.wiley\\.com/loi/14682303(/year/\\d{4})?",
+    "volume_pattern": "onlinelibrary\\.wiley\\.com/loi/14682303/year/\\d{4}$",
+    "crawl_pattern": "onlinelibrary\\.wiley\\.com/toc/14682303/\\d{4}/\\d+/(\\d+|\\d+-\\d+)$",
+    "extraction_pattern": "onlinelibrary\\.wiley\\.com/doi/10\\.1111/((j\\.)?\\d{4}-\\d{4}\\.\\d+(?:\\.\\w+\\.x)?|hith\\.\\d+)",
+    "crawl": true,
+    "site": "History and theory : studies in the philosophy of history",
+    "selectors": {
+      "linkSelector": "a.href",
+      "titleSelector": "h2",
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "dialnet.unirioja.es/servlet/revista?codigo=273": {
+    "pattern": "https://dialnet\\.unirioja\\.es/servlet/revista\\?codigo=273$",
+    "volume_pattern": "",
+    "crawl_pattern": "https://dialnet\\.unirioja\\.es/ejemplar/\\d+$",
+    "extraction_pattern": "https://dialnet\\.unirioja\\.es/servlet/articulo\\?codigo=\\d+$",
+    "crawl": true,
+    "site": "Carthaginensia : revista de estudios e investigación",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "tidsskrift.dk": {
+    "pattern": "https://tidsskrift\\.dk/grs/issue/archive(/\\d+)?$",
+    "volume_pattern": "https://tidsskrift\\.dk/grs/issue/archive(/\\d+)?$",
+    "crawl_pattern": "https://tidsskrift\\.dk/grs/issue/view/\\d+$",
+    "extraction_pattern": "https://tidsskrift\\.dk/grs/article/view/\\d+$",
+    "crawl": true,
+    "site": "Grundtvig-studier : Grundtvig-Selskabets °arbog",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "raco.cat": {
+    "pattern": "https://raco\\.cat/index\\.php/Miscellania/issue/archive(/\\d+)?$",
+    "volume_pattern": "https://raco\\.cat/index\\.php/Miscellania/issue/archive(/\\d+)?$",
+    "crawl_pattern": "https://raco\\.cat/index\\.php/Miscellania/issue/view/\\d+$",
+    "extraction_pattern": "https://raco\\.cat/index\\.php/Miscellania/article/view/\\d+$",
+    "crawl": true,
+    "site": "Miscellània litúrgica catalana",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "repositorio.uca.edu.ar": {
+    "pattern": "https://repositorio\\.uca\\.edu\\.ar/handle/123456789/3317",
+    "volume_pattern": "",
+    "crawl_pattern": "https://repositorio\\.uca\\.edu\\.ar/handle/123456789/\\d+$",
+    "extraction_pattern": "https://repositorio\\.uca\\.edu\\.ar/handle/123456789/\\d+$",
+    "crawl": true,
+    "site": "Sapientia",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "journals.lub.lu.se": {
+    "pattern": "https://journals\\.lub\\.lu\\.se/sgl/issue/archive(/\\d+)?$",
+    "volume_pattern": "https://journals\\.lub\\.lu\\.se/sgl/issue/archive(/\\d+)?$",
+    "crawl_pattern": "https://journals\\.lub\\.lu\\.se/sgl/issue/view/\\d+$",
+    "extraction_pattern": "https://journals\\.lub\\.lu\\.se/sgl/article/view/\\d+$",
+    "crawl": true,
+    "site": "Svenskt gudstjänstliv : årsbok för liturgi, kyrkokonst, kyrkomusik och homiletik_ Laurentius",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "revistas.javeriana.edu.co": {
+    "pattern": "https://revistas\\.javeriana\\.edu\\.co/index\\.php/teoxaveriana/issue/archive(/\\d+)?$",
+    "volume_pattern": "https://revistas\\.javeriana\\.edu\\.co/index\\.php/teoxaveriana/issue/archive(/\\d+)?$",
+    "crawl_pattern": "https://revistas\\.javeriana\\.edu\\.co/index\\.php/teoxaveriana/issue/view/\\d+$",
+    "extraction_pattern": "https://revistas\\.javeriana\\.edu\\.co/index\\.php/teoxaveriana/article/view/\\d+$",
+    "crawl": true,
+    "site": "Theologica Xaveriana : revista de la Facultad de Teología, Pontificia Universidad Javeriana",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "periodicos.est.edu.br": {
+    "pattern": "http://periodicos.est.edu.br/index.php/nepp/issue/archive",
+    "volume_pattern": "",
+    "crawl_pattern": "http://periodicos\\.est\\.edu\\.br/index\\.php/nepp/issue/view/\\d+(/showToc)?$",
+    "extraction_pattern": "http://periodicos\\.est\\.edu\\.br/index\\.php/nepp/article/view/\\d+$",
+    "crawl": true,
+    "site": "Protestantismo em Revista",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "journals.uchicago.edu": {
+    "pattern": "https://www\\.journals\\.uchicago\\.edu/loi/jnes",
+    "volume_pattern": "",
+    "crawl_pattern": "http://periodicos\\.est\\.edu\\.br/index\\.php/nepp/issue/view/\\d+(/showToc)?$",
+    "extraction_pattern": "http://periodicos\\.est\\.edu\\.br/index\\.php/nepp/article/view/\\d+$",
+    "crawl": true,
+    "site": "Journal of Near Eastern studies",
+    "selectors": {
+      "linkSelector": null,
+      "titleSelector": null,
+      "linkAttr": "href"
+    },
+    "max_links": 5
+  },
+    "revistas.ucsp.edu.pe": {
+    "pattern": "https://revistas\\.ucsp\\.edu\\.pe/index\\.php/Allpanchis/issue/archive(/\\d+)?$",
+    "volume_pattern": "https://revistas\\.ucsp\\.edu\\.pe/index\\.php/Allpanchis/issue/archive(/\\d+)?$",
+    "crawl_pattern": "https://revistas\\.ucsp\\.edu\\.pe/index\\.php/Allpanchis/issue/view/\\d+$",
+    "extraction_pattern": "https://revistas\\.ucsp\\.edu\\.pe/index\\.php/Allpanchis/article/view/\\d+$",
+    "crawl": true,
+    "site": "Allpanchis : revista anual_ organo del Instituto Pastoral Andina (IPA)",
     "selectors": {
       "linkSelector": null,
       "titleSelector": null,


### PR DESCRIPTION
Addresses issues of all issue pages being opened simultaneously, content-script being injected into the same page twice and the alert being shown inside the extensions popup resulting in an inability to close it.
Adds support for multiple journals.